### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,8 +27,8 @@
           <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
             <div class="navbar-nav">
               <a class="nav-item nav-link {{ if eq .URL "/"}}active{{ end }}" href="/">Home</a>
-              {{ with .Site.Params.github }}<a class="nav-item nav-link" href="https://github.com/{{ . }}" target="_blank">GitHub</a>{{ end }}
-              {{ with .Site.Params.gitlab }}<a class="nav-item nav-link" href="https://gitlab.com/{{ . }}" target="_blank">GitLab</a>{{ end }}
+              {{ with .Site.Params.github }}<a class="nav-item nav-link" href="https://github.com/{{ . }}" rel="me" target="_blank">GitHub</a>{{ end }}
+              {{ with .Site.Params.gitlab }}<a class="nav-item nav-link" href="https://gitlab.com/{{ . }}" rel="me" target="_blank">GitLab</a>{{ end }}
               <a class="nav-item nav-link {{ if eq .URL "/about/"}}active{{ end }}" href="/about/">About</a>
             </div>
           </div>


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.