### PR TITLE
Add `showthedate` param

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,11 @@
 {{ define "content" }}
 <div class="blog-post">
   <h1>{{ .Title }}</h1>
+  {{ if .Params.showthedate | default "true" }}
   <div class="blog-post-subheader">
     <time>{{ .Date.Format "02 Jan 2006" }}</time>
   </div>
+  {{ end }}
   <div class="blog-post-content">
     {{ .Content }}
   </div>


### PR DESCRIPTION
I've added parmaeter `showthedate`. On my site I have pages such as "about" that do not need a date in its header. If I add parameter `showthedate: false` in the yaml header then it hides the date.